### PR TITLE
fixed variable arg access

### DIFF
--- a/src/variable-resolver.ts
+++ b/src/variable-resolver.ts
@@ -13,7 +13,7 @@ const replaceToken = async (
   g1: string,
   ...args: any[]
 ): Promise<string> => {
-  const g2 = (args: any[]) => (args.length > 3 ? args[0] : null)
+  const g2 = (args: any[]) => (args.length > 2 ? args[0] : null)
   switch (g1) {
     case 'env':
       return await getEnv(context, g2(args))


### PR DESCRIPTION
Accessing variables with additional arguments was broken. Fixes the access.

```
"${config:some-setting} ${env:environment-value} ${workspaceFolder:services}"
```

Do note that further `${input:name}` variables aren't supported, I'm not sure if it could be resolved.