### PR TITLE
feat: Adds append to redirect output

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -361,6 +361,13 @@ function executeJqCommand(params, variables) {
     contextLine++;
     lineOffset++;
   }
+  let appendToOutputFile = true;
+  if (document.lineAt(contextLine)?.text?.startsWith(">> ")) {
+    outputFile = document.lineAt(contextLine).text.replace(">> ", "").trim();
+    appendToOutputFile = true;
+    contextLine++;
+    lineOffset++;
+  }
   const context: string = document.lineAt(contextLine)?.text;
   lineOffset++;
 
@@ -375,7 +382,11 @@ function executeJqCommand(params, variables) {
     }
 
     if (outFile) {
-      fs.writeFileSync(outFile, out);
+      if (appendToOutputFile) {
+        fs.appendFileSync(outFile, out);
+      } else {
+        fs.writeFileSync(outFile, out);
+      }
     } else {
       renderOutput(params.openResult)(out);
     }


### PR DESCRIPTION
## Suggestion: Allow `>> output` to append to output

Just like in the command line, where `>` is used to overwrite a file and `>>` is used to append to a file.

It would be great for [vscode-jq-playground](https://github.com/davidnussio/vscode-jq-playground) to support `>>` as well. This is particularly useful on _.jsonl_ files new json lines can be appended. This is a first pass at it:

I believe this is handled in:
https://github.com/davidnussio/vscode-jq-playground/blob/master/src/extension.ts#L358:L382

```ts
 let outputFile = "";
  if (document.lineAt(contextLine)?.text?.startsWith("> ")) {
    outputFile = document.lineAt(contextLine).text.replace("> ", "").trim();
    contextLine++;
    lineOffset++;
  }
```

* I repeated the entire `if` but for `">> "`, should I use a regular expression to capture both and read the `outputFile`.
* I added set `appendToOutputFile = true` when ">> " is found.
* Then we ask if it should append (use `fs.appendFileSync`) or replace (`fs.writeFileSync`) the contents to `outFile`

I wasn't sure on how to test my changes:
* `npx jest` triggers a `UnhandledPromiseRejection`
* `npm run test` runs the "pretest" script and fails `npm run compile` with "Found 88 errors."
* `npm run lint` finds `✖ 5 problems (0 errors, 5 warnings)`

Thanks for this great extension, it truly helps working with `jq` snippets. 